### PR TITLE
feat: improve error message

### DIFF
--- a/R/utils-wrap.R
+++ b/R/utils-wrap.R
@@ -2,7 +2,12 @@ wrap <- function(x, ..., call = parent.frame()) {
   try_fetch(
     x,
     error = function(cnd) {
-      abort("Evaluation failed.", call = call, parent = cnd)
+      err_call <- rlang::error_call(call)[[1]]
+      abort(
+        paste0("Evaluation failed in `$", err_call[[length(err_call)]], "()`."),
+        call = call,
+        parent = cnd
+      )
     }
   )
 


### PR DESCRIPTION
Naive attempt to include the last method called in the error message as it is something really useful when the pipeline is quite long:

```r
> as_polars_df(mtcars)$group_by("cyl")$head(-Inf)
Error:
! Evaluation failed in `$head()`.
Caused by error:
! n should not be negative
Run `rlang::last_trace()` to see where the error occurred.
```

Not sure how it would behave with `LazyFrame` since the last method should be `collect()` and the method before that is not necessarily the one that errors.