### PR TITLE
fix: add missing libraries in makevars.win for windows builds

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,7 +6,7 @@ PROFILE = $(subst x,release,$(subst truex,dev,$(DEBUG)x))
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))
 STATLIB = $(LIBDIR)/libr_polars.a
-PKG_LIBS = -L$(LIBDIR) -lr_polars -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
+PKG_LIBS = -L$(LIBDIR) -lr_polars -lws2_32 -lncrypt -lcrypt32 -ladvapi32 -luserenv -lbcrypt -lole32 -lntdll -lpsapi -liphlpapi -lpdh -lpowrprof -loleaut32 -lnetapi32 -lsecur32 -lsynchronization -lpropsys -lruntimeobject -t
 
 # Rtools doesn't have the linker in the location that cargo expects, so we need
 # to overwrite it via configuration.


### PR DESCRIPTION
Trying to take a look at the progress in `neo-r-polars` but ran into `undefined reference to 'CoTaskMemFree'` when compiling. I remember this was fixed in `r-polars` by one the pkg libs added in this PR but I don't remember which one so I just copy the list from r-polars.

