### PR TITLE
!! DO NOT MERGE !! Use `"use-custom-error"` feature of savvy

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2527,8 +2527,7 @@ dependencies = [
 [[package]]
 name = "savvy"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9901422223436007d21f5448a8125b05c2243ede8f48fe5701349ff6c59a43ad"
+source = "git+https://github.com/yutannihilation/savvy.git?branch=feat/error-conversion2#10512b3b26955edad412d6e25c0a3f159dce1038"
 dependencies = [
  "cc",
  "once_cell",
@@ -2540,8 +2539,7 @@ dependencies = [
 [[package]]
 name = "savvy-bindgen"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24dfb64e9d4c9ba228c319c681268fcca9ed2bf6bbfdbe12e9b6f33208df3974"
+source = "git+https://github.com/yutannihilation/savvy.git?branch=feat/error-conversion2#10512b3b26955edad412d6e25c0a3f159dce1038"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2551,14 +2549,12 @@ dependencies = [
 [[package]]
 name = "savvy-ffi"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f220d5024651069932f5ce857b128d11510a1ba197672cc208383771de51a334"
+source = "git+https://github.com/yutannihilation/savvy.git?branch=feat/error-conversion2#10512b3b26955edad412d6e25c0a3f159dce1038"
 
 [[package]]
 name = "savvy-macro"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2545c3adb18a7ce7adae4242deeda25e9fccea58f28bc389338caa0e98853182"
+source = "git+https://github.com/yutannihilation/savvy.git?branch=feat/error-conversion2#10512b3b26955edad412d6e25c0a3f159dce1038"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -15,7 +15,9 @@ ciborium = "0.2"
 flume = "0.11"
 polars-core = { git = "https://github.com/pola-rs/polars.git", rev = "1c1574add6a0077aad69064e79c00414114fc28e", default-features = false }
 polars-error = { git = "https://github.com/pola-rs/polars.git", rev = "1c1574add6a0077aad69064e79c00414114fc28e", default-features = false }
-savvy = "0.7"
+savvy = { git = "https://github.com/yutannihilation/savvy.git", branch = "feat/error-conversion2", features = [
+    "use-custom-error",
+] }
 serde_json = "1"
 state = "0.6"
 strum = "0.26"


### PR DESCRIPTION
I'm planning to provide `impl<E: std::error::Error> From<E> for savvy::Error` for easy error-conversion like anyhow.

Details: https://github.com/yutannihilation/savvy/pull/324

This is a breaking change in that this will conflicts with `impl From<RPolarsErr> for savvy::Error`. So, savvy will provide a feature `use-custom-error` to opt-out the conversion of `From<dyn std::error::Error>`. This pull request is to see if it works. Please let me know if you have any concerns.

```
   error[E0119]: conflicting implementations of trait `From<RPolarsErr>` for type `savvy::Error`
     --> src\error.rs:27:1
      |
   27 | impl From<RPolarsErr> for savvy::Error {
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: conflicting implementation in crate `savvy`:
              - impl<E> From<E> for savvy::Error
                where E: StdError, E: 'static;
```