### PR TITLE
docs: fix math notation in `emw_` functions

### DIFF
--- a/R/expr-expr.R
+++ b/R/expr-expr.R
@@ -3322,8 +3322,8 @@ expr__rolling_var_by <- function(
 #' account for imbalance in relative weightings:
 #' * when `TRUE` (default), the EW function is calculated using weights
 #'  \eqn{w_i = (1 - \alpha)^i};
-#' * when `FALSE`, the EW function is calculated recursively by \deqn{y_0 &= x_0
-#'  \\y_t &= (1 - \alpha)y_{t - 1} + \alpha x_t}
+#' * when `FALSE`, the EW function is calculated recursively by \deqn{y_0 = x_0
+#'  ; y_t = (1 - \alpha)y_{t - 1} + \alpha x_t}
 #' @param bias If `FALSE` (default), apply a correction to make the estimate
 #' statistically unbiased.
 #' @param ignore_nulls Ignore missing values when calculating weights.

--- a/man/expr__ewm_mean.Rd
+++ b/man/expr__ewm_mean.Rd
@@ -36,8 +36,8 @@ account for imbalance in relative weightings:
 \itemize{
 \item when \code{TRUE} (default), the EW function is calculated using weights
 \eqn{w_i = (1 - \alpha)^i};
-\item when \code{FALSE}, the EW function is calculated recursively by \deqn{y_0 &= x_0
- \\y_t &= (1 - \alpha)y_{t - 1} + \alpha x_t}
+\item when \code{FALSE}, the EW function is calculated recursively by \deqn{y_0 = x_0
+ ; y_t = (1 - \alpha)y_{t - 1} + \alpha x_t}
 }}
 
 \item{min_periods}{The number of values in the window that should be

--- a/man/expr__ewm_std.Rd
+++ b/man/expr__ewm_std.Rd
@@ -37,8 +37,8 @@ account for imbalance in relative weightings:
 \itemize{
 \item when \code{TRUE} (default), the EW function is calculated using weights
 \eqn{w_i = (1 - \alpha)^i};
-\item when \code{FALSE}, the EW function is calculated recursively by \deqn{y_0 &= x_0
- \\y_t &= (1 - \alpha)y_{t - 1} + \alpha x_t}
+\item when \code{FALSE}, the EW function is calculated recursively by \deqn{y_0 = x_0
+ ; y_t = (1 - \alpha)y_{t - 1} + \alpha x_t}
 }}
 
 \item{bias}{If \code{FALSE} (default), apply a correction to make the estimate

--- a/man/expr__ewm_var.Rd
+++ b/man/expr__ewm_var.Rd
@@ -37,8 +37,8 @@ account for imbalance in relative weightings:
 \itemize{
 \item when \code{TRUE} (default), the EW function is calculated using weights
 \eqn{w_i = (1 - \alpha)^i};
-\item when \code{FALSE}, the EW function is calculated recursively by \deqn{y_0 &= x_0
- \\y_t &= (1 - \alpha)y_{t - 1} + \alpha x_t}
+\item when \code{FALSE}, the EW function is calculated recursively by \deqn{y_0 = x_0
+ ; y_t = (1 - \alpha)y_{t - 1} + \alpha x_t}
 }}
 
 \item{bias}{If \code{FALSE} (default), apply a correction to make the estimate


### PR DESCRIPTION
Addresses https://github.com/eitsupi/neo-r-polars/pull/19#discussion_r1864119287

Now:

![image](https://github.com/user-attachments/assets/73e0d6b2-2e3a-4336-a41c-384816d78271)
