### PR TITLE
feat: Add argument `as_dot` in `$meta$tree_format()`

### DIFF
--- a/R/expr-meta.R
+++ b/R/expr-meta.R
@@ -192,6 +192,7 @@ expr_meta_root_names <- function() {
 
 #' Format the expression as a tree
 #'
+#' @inheritParams rlang::args_dots_empty
 #' @param as_dot If `TRUE`, show the dot syntax that can be used in other
 #' packages, such as `DiagrammeR`.
 #'
@@ -208,9 +209,11 @@ expr_meta_root_names <- function() {
 #' graph <- my_expr$meta$tree_format(as_dot = TRUE)
 #' DiagrammeR::grViz(graph)
 #' }
-expr_meta_tree_format <- function(as_dot = FALSE) {
-  self$`_rexpr`$compute_tree_format(display_as_dot = as_dot) |>
-    wrap()
+expr_meta_tree_format <- function(..., as_dot = FALSE) {
+  wrap({
+    check_dots_empty0(...)
+    self$`_rexpr`$compute_tree_format(display_as_dot = as_dot)
+  })
 }
 
 

--- a/man/expr_meta_tree_format.Rd
+++ b/man/expr_meta_tree_format.Rd
@@ -4,9 +4,11 @@
 \alias{expr_meta_tree_format}
 \title{Format the expression as a tree}
 \usage{
-expr_meta_tree_format(as_dot = FALSE)
+expr_meta_tree_format(..., as_dot = FALSE)
 }
 \arguments{
+\item{...}{These dots are for future extensions and must be empty.}
+
 \item{as_dot}{If \code{TRUE}, show the dot syntax that can be used in other
 packages, such as \code{DiagrammeR}.}
 }

--- a/tests/testthat/_snaps/expr-meta.md
+++ b/tests/testthat/_snaps/expr-meta.md
@@ -33,7 +33,7 @@
 # meta$tree_format
 
     Code
-      cat(e$meta$tree_format(FALSE))
+      cat(e$meta$tree_format())
     Output
                   0             1              2             3
          ┌──────────────────────────────────────────────────────────
@@ -69,7 +69,7 @@
 ---
 
     Code
-      cat(e$meta$tree_format(TRUE))
+      cat(e$meta$tree_format(as_dot = TRUE))
     Output
       graph {
           n00 [label="binary: /", ordering="out"]

--- a/tests/testthat/test-expr-meta.R
+++ b/tests/testthat/test-expr-meta.R
@@ -101,10 +101,10 @@ test_that("meta$is_column_selection", {
 
 test_that("meta$tree_format", {
   e <- (pl$col("foo") * pl$col("bar"))$sum()$over(pl$col("ham")) / 2
-  expect_true(is.character(e$meta$tree_format(FALSE)))
-  expect_true(is.character(e$meta$tree_format(TRUE)))
-  expect_snapshot(cat(e$meta$tree_format(FALSE)))
-  expect_snapshot(cat(e$meta$tree_format(TRUE)))
+  expect_true(is.character(e$meta$tree_format()))
+  expect_true(is.character(e$meta$tree_format(as_dot = TRUE)))
+  expect_snapshot(cat(e$meta$tree_format()))
+  expect_snapshot(cat(e$meta$tree_format(as_dot = TRUE)))
 })
 
 test_that("meta$serialize", {


### PR DESCRIPTION
I think we talked before about whether we should include the options to print / save the graph using external packages. I don't remember the decision, but no problem to add / remove functionalities here.