### PR TITLE
fix: `wrap()` early return in join

### DIFF
--- a/R/lazyframe-frame.R
+++ b/R/lazyframe-frame.R
@@ -1197,7 +1197,8 @@ lazyframe__join <- function(
           join_nulls = join_nulls, suffix = suffix,
           allow_parallel = allow_parallel, force_parallel = force_parallel,
           coalesce = coalesce, maintain_order = maintain_order
-        )
+        ) |>
+          wrap()
       )
     }
 


### PR DESCRIPTION
Found while exploring #86 but not a fix unfortunately