### PR TITLE
fix: Fix `<expr>$map_batches()` crashing R session

### DIFF
--- a/tests/testthat/_snaps/expr-expr.md
+++ b/tests/testthat/_snaps/expr-expr.md
@@ -1,3 +1,39 @@
+# map_batches works
+
+    Code
+      .data$select(pl$col("a")$map_batches(function(...) integer))
+    Condition
+      Error:
+      ! Evaluation failed in `$select()`.
+      Caused by error:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! Unsupported class for `as_polars_series()`: function
+      Error:
+      ! Evaluation failed in `$select()`.
+      Caused by error:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! User function raised an error
+
+---
+
+    Code
+      .data$select(pl$col("a")$map_batches(function(...) 0+1i))
+    Condition
+      Error:
+      ! Evaluation failed in `$select()`.
+      Caused by error:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! Unsupported class for `as_polars_series()`: complex
+      Error:
+      ! Evaluation failed in `$select()`.
+      Caused by error:
+      ! Evaluation failed in `$collect()`.
+      Caused by error:
+      ! User function raised an error
+
 # $over() with mapping_strategy
 
     Code

--- a/tests/testthat/test-expr-expr.R
+++ b/tests/testthat/test-expr-expr.R
@@ -1,6 +1,4 @@
 test_that("map_batches works", {
-  skip("map_batches seems buggy (Stacking observed on R-universe builder)")
-
   .data <- pl$DataFrame(a = c(0, 1, 0, 1), b = 1:4)
 
   expect_query_equal(
@@ -26,6 +24,10 @@ test_that("map_batches works", {
   )
   expect_snapshot(
     .data$select(pl$col("a")$map_batches(\(...) integer)),
+    error = TRUE
+  )
+  expect_snapshot(
+    .data$select(pl$col("a")$map_batches(\(...) 1i)),
     error = TRUE
   )
 })


### PR DESCRIPTION
Fix #5

I definitely misunderstood the protection and release of R objects.
I don't think there is any need for special protection on the Rust side since the function object is copied when it is passed.