### PR TITLE
docs: Fix formatting and description of `group_by_dynamic()`

### DIFF
--- a/R/lazyframe-frame.R
+++ b/R/lazyframe-frame.R
@@ -1693,12 +1693,13 @@ lazyframe__rolling <- function(
 
 #' Group based on a date/time or integer column
 #'
+#' @description
 #' Time windows are calculated and rows are assigned to windows. Different from
 #' a normal group by is that a row can be member of multiple groups. By
 #' default, the windows look like:
 #' * [start, start + period)
 #' * [start + every, start + every + period)
-#' * [start + 2*every, start + 2*every + period)
+#' * [start + 2 * every, start + 2 * every + period)
 #' * …
 #'
 #' where `start` is determined by `start_by`, `offset`, `every`, and the

--- a/man/dataframe__group_by_dynamic.Rd
+++ b/man/dataframe__group_by_dynamic.Rd
@@ -75,14 +75,14 @@ default, the windows look like:
 \itemize{
 \item [start, start + period)
 \item [start + every, start + every + period)
-\item [start + 2\emph{every, start + 2}every + period)
+\item [start + 2 * every, start + 2 * every + period)
 \item …
 }
-}
-\details{
+
 where \code{start} is determined by \code{start_by}, \code{offset}, \code{every}, and the
 earliest datapoint. See the \code{start_by} argument description for details.
-
+}
+\details{
 The \code{every}, \code{period}, and \code{offset} arguments are created with the following
 string language:
 \itemize{

--- a/man/lazyframe__group_by_dynamic.Rd
+++ b/man/lazyframe__group_by_dynamic.Rd
@@ -75,14 +75,14 @@ default, the windows look like:
 \itemize{
 \item [start, start + period)
 \item [start + every, start + every + period)
-\item [start + 2\emph{every, start + 2}every + period)
+\item [start + 2 * every, start + 2 * every + period)
 \item …
 }
-}
-\details{
+
 where \code{start} is determined by \code{start_by}, \code{offset}, \code{every}, and the
 earliest datapoint. See the \code{start_by} argument description for details.
-
+}
+\details{
 The \code{every}, \code{period}, and \code{offset} arguments are created with the following
 string language:
 \itemize{


### PR DESCRIPTION
* Added a space around `*` so that it's not considered markdown formatting (using `\*` doesn't work as it keeps the backslash in docs)
* Added `@description` so that the second half of the description doesn't end up in "Details"