### PR TITLE
feat: Support converting polars objects to some arrow objects via the Arrow C stream interface

### DIFF
--- a/R/dataframe-s3-arrow.R
+++ b/R/dataframe-s3-arrow.R
@@ -1,0 +1,31 @@
+# exported in zzz.R
+as_record_batch_reader.polars_data_frame <- function(
+  x,
+  ...,
+  polars_compat_level = c("newest", "oldest")
+) {
+  as_polars_series(x) |>
+    as_record_batch_reader.polars_series(..., polars_compat_level = polars_compat_level)
+}
+
+# exported in zzz.R
+as_arrow_table.polars_data_frame <- function(
+  x,
+  ...,
+  polars_compat_level = c("newest", "oldest")
+) {
+  try_fetch(
+    {
+      as_record_batch_reader.polars_data_frame(
+        x,
+        polars_compat_level = polars_compat_level
+      )$read_table()
+    },
+    error = function(cnd) {
+      abort(
+        "Evaluation failed.",
+        parent = cnd
+      )
+    }
+  )
+}

--- a/R/series-s3-arrow.R
+++ b/R/series-s3-arrow.R
@@ -1,0 +1,24 @@
+# exported in zzz.R
+as_record_batch_reader.polars_series <- function(
+  x,
+  ...,
+  polars_compat_level = c("newest", "oldest")
+) {
+  try_fetch(
+    {
+      polars_compat_level <- arg_match_compat_level(polars_compat_level)
+
+      # This function is not exported from the arrow package
+      # <https://github.com/apache/arrow/issues/39793>
+      stream <- utils::getFromNamespace("allocate_arrow_array_stream", "arrow")()
+      x$`_s`$to_arrow_c_stream(stream, polars_compat_level = polars_compat_level)
+      arrow::RecordBatchReader$import_from_c(stream)
+    },
+    error = function(cnd) {
+      abort(
+        "Evaluation failed.",
+        parent = cnd
+      )
+    }
+  )
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -98,6 +98,9 @@ on_load(local_use_cli())
   run_on_load()
 
   # Register S3 methods for optional packages
+  s3_register("arrow::as_arrow_table", "polars_data_frame")
+  s3_register("arrow::as_record_batch_reader", "polars_data_frame")
+  s3_register("arrow::as_record_batch_reader", "polars_series")
   s3_register("nanoarrow::as_nanoarrow_array_stream", "polars_data_frame")
   s3_register("nanoarrow::as_nanoarrow_array_stream", "polars_series")
   s3_register("tibble::as_tibble", "polars_data_frame")

--- a/tests/testthat/_snaps/dataframe-s3-arrow.md
+++ b/tests/testthat/_snaps/dataframe-s3-arrow.md
@@ -1,0 +1,30 @@
+# polars_compat_level works
+
+    Code
+      arrow::as_arrow_table(pl$DataFrame(x = letters[1:3]), polars_compat_level = "oldest")
+    Output
+      Table
+      3 rows x 1 columns
+      $x <large_string>
+
+---
+
+    Code
+      arrow::as_arrow_table(pl$DataFrame(x = letters[1:3]), polars_compat_level = "newest")
+    Output
+      Table
+      3 rows x 1 columns
+      $x <string_view>
+
+---
+
+    Code
+      arrow::as_arrow_table(pl$DataFrame(x = letters[1:3]), polars_compat_level = TRUE)
+    Condition
+      Error in `arrow::as_arrow_table()`:
+      ! Evaluation failed.
+      Caused by error in `as_record_batch_reader.polars_series()`:
+      ! Evaluation failed.
+      Caused by error in `as_record_batch_reader.polars_series()`:
+      ! `polars_compat_level` must be a string or an integerish scalar value, got: logical
+

--- a/tests/testthat/_snaps/series-s3-arrow.md
+++ b/tests/testthat/_snaps/series-s3-arrow.md
@@ -1,0 +1,10 @@
+# Only struct type is allowed
+
+    Code
+      arrow::as_record_batch_reader(as_polars_series(1:3))
+    Condition
+      Error in `arrow::as_record_batch_reader()`:
+      ! Evaluation failed.
+      Caused by error:
+      ! Invalid: Cannot import schema: ArrowSchema describes non-struct type int32
+

--- a/tests/testthat/test-dataframe-s3-arrow.R
+++ b/tests/testthat/test-dataframe-s3-arrow.R
@@ -1,0 +1,31 @@
+test_that("roundtrip via arrow table", {
+  skip_if_not_installed("arrow")
+
+  df <- pl$DataFrame(
+    x = 1:3,
+    y = letters[1:3],
+  )
+
+  from_arrow <- arrow::as_arrow_table(df) |>
+    as_polars_df()
+
+  expect_equal(from_arrow, df)
+})
+
+test_that("polars_compat_level works", {
+  skip_if_not_installed("arrow")
+
+  expect_snapshot(
+    pl$DataFrame(x = letters[1:3]) |>
+      arrow::as_arrow_table(polars_compat_level = "oldest")
+  )
+  expect_snapshot(
+    pl$DataFrame(x = letters[1:3]) |>
+      arrow::as_arrow_table(polars_compat_level = "newest")
+  )
+  expect_snapshot(
+    pl$DataFrame(x = letters[1:3]) |>
+      arrow::as_arrow_table(polars_compat_level = TRUE),
+    error = TRUE
+  )
+})

--- a/tests/testthat/test-series-s3-arrow.R
+++ b/tests/testthat/test-series-s3-arrow.R
@@ -1,0 +1,11 @@
+# Mostly tested in dataframe-s3-arrow
+
+test_that("Only struct type is allowed", {
+  skip_if_not_installed("arrow")
+
+  expect_snapshot(
+    as_polars_series(1:3) |>
+      arrow::as_record_batch_reader(),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
I think it is necessary to recommend the use of `nanoarrow` instead of `arrow` in most cases, which is why they are not documented at this time.
(In other words, when going through nanoarrow_array_stream, it is possible to move between each package with zero-copy, so there is no need to implement methods for functions of the arrow package here.)