### PR TITLE
fix: Add missing `...` argument in `wrap.PlRSQLContext()`

### DIFF
--- a/R/sql-context.R
+++ b/R/sql-context.R
@@ -2,7 +2,7 @@
 polars_sql_context__methods <- new.env(parent = emptyenv())
 
 #' @export
-wrap.PlRSQLContext <- function(x) {
+wrap.PlRSQLContext <- function(x, ...) {
   self <- new.env(parent = emptyenv())
   self$`_ctxt` <- x
 


### PR DESCRIPTION
Fixes the R CMD check warning "checking S3 generic/method consistency"