### PR TITLE
feat: The new `engine` argument of `<lazyframe>$collect()` to switch query engine

### DIFF
--- a/R/000-wrappers.R
+++ b/R/000-wrappers.R
@@ -3547,8 +3547,8 @@ class(`PlRExpr`) <- c("PlRExpr__bundle", "savvy_neopolars__sealed")
 }
 
 `PlRLazyFrame_collect` <- function(self) {
-  function() {
-    .savvy_wrap_PlRDataFrame(.Call(savvy_PlRLazyFrame_collect__impl, `self`))
+  function(`engine`) {
+    .savvy_wrap_PlRDataFrame(.Call(savvy_PlRLazyFrame_collect__impl, `self`, `engine`))
   }
 }
 

--- a/R/lazyframe-frame.R
+++ b/R/lazyframe-frame.R
@@ -159,6 +159,8 @@ lazyframe__group_by <- function(..., .maintain_order = FALSE) {
 }
 
 # TODO: see also section
+# TODO: Enable new-streaming feature and the default value of engine to auto (If without new-streaming, panic)
+# TODO: The panic issue above must be fixed on the upstream
 #' Materialize this LazyFrame into a DataFrame
 #'
 #' By default, all query optimizations are enabled.
@@ -219,12 +221,18 @@ lazyframe__collect <- function(
   cluster_with_columns = TRUE,
   collapse_joins = TRUE,
   no_optimization = FALSE,
+  engine = c("in-memory", "old-streaming"),
   streaming = FALSE,
   `_check_order` = TRUE,
   `_eager` = FALSE
 ) {
   wrap({
     check_dots_empty0(...)
+    engine <- arg_match0(engine, c("in-memory", "old-streaming"))
+    # TODO: remove the streaming argument
+    if (isTRUE(streaming)) {
+      engine <- "old-streaming"
+    }
 
     if (isTRUE(no_optimization) || isTRUE(`_eager`)) {
       predicate_pushdown <- FALSE
@@ -253,7 +261,7 @@ lazyframe__collect <- function(
       `_eager` = `_eager`
     )
 
-    ldf$collect()
+    ldf$collect(engine)
   })
 }
 

--- a/man/lazyframe__collect.Rd
+++ b/man/lazyframe__collect.Rd
@@ -17,6 +17,7 @@ lazyframe__collect(
   cluster_with_columns = TRUE,
   collapse_joins = TRUE,
   no_optimization = FALSE,
+  engine = c("in-memory", "old-streaming"),
   streaming = FALSE,
   `_check_order` = TRUE,
   `_eager` = FALSE

--- a/src/init.c
+++ b/src/init.c
@@ -2414,8 +2414,8 @@ SEXP savvy_PlRLazyFrame_clone__impl(SEXP self__) {
     return handle_result(res);
 }
 
-SEXP savvy_PlRLazyFrame_collect__impl(SEXP self__) {
-    SEXP res = savvy_PlRLazyFrame_collect__ffi(self__);
+SEXP savvy_PlRLazyFrame_collect__impl(SEXP self__, SEXP c_arg__engine) {
+    SEXP res = savvy_PlRLazyFrame_collect__ffi(self__, c_arg__engine);
     return handle_result(res);
 }
 
@@ -3432,7 +3432,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"savvy_PlRLazyFrame_cast__impl", (DL_FUNC) &savvy_PlRLazyFrame_cast__impl, 3},
     {"savvy_PlRLazyFrame_cast_all__impl", (DL_FUNC) &savvy_PlRLazyFrame_cast_all__impl, 3},
     {"savvy_PlRLazyFrame_clone__impl", (DL_FUNC) &savvy_PlRLazyFrame_clone__impl, 1},
-    {"savvy_PlRLazyFrame_collect__impl", (DL_FUNC) &savvy_PlRLazyFrame_collect__impl, 1},
+    {"savvy_PlRLazyFrame_collect__impl", (DL_FUNC) &savvy_PlRLazyFrame_collect__impl, 2},
     {"savvy_PlRLazyFrame_collect_schema__impl", (DL_FUNC) &savvy_PlRLazyFrame_collect_schema__impl, 1},
     {"savvy_PlRLazyFrame_count__impl", (DL_FUNC) &savvy_PlRLazyFrame_count__impl, 1},
     {"savvy_PlRLazyFrame_describe_optimized_plan__impl", (DL_FUNC) &savvy_PlRLazyFrame_describe_optimized_plan__impl, 1},

--- a/src/rust/api.h
+++ b/src/rust/api.h
@@ -486,7 +486,7 @@ SEXP savvy_PlRLazyFrame_cache__ffi(SEXP self__);
 SEXP savvy_PlRLazyFrame_cast__ffi(SEXP self__, SEXP c_arg__dtypes, SEXP c_arg__strict);
 SEXP savvy_PlRLazyFrame_cast_all__ffi(SEXP self__, SEXP c_arg__dtype, SEXP c_arg__strict);
 SEXP savvy_PlRLazyFrame_clone__ffi(SEXP self__);
-SEXP savvy_PlRLazyFrame_collect__ffi(SEXP self__);
+SEXP savvy_PlRLazyFrame_collect__ffi(SEXP self__, SEXP c_arg__engine);
 SEXP savvy_PlRLazyFrame_collect_schema__ffi(SEXP self__);
 SEXP savvy_PlRLazyFrame_count__ffi(SEXP self__);
 SEXP savvy_PlRLazyFrame_describe_optimized_plan__ffi(SEXP self__);

--- a/src/rust/src/conversion/mod.rs
+++ b/src/rust/src/conversion/mod.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroUsize;
+use std::str::FromStr;
 
 use crate::prelude::*;
 use crate::{PlRDataFrame, PlRDataType, PlRExpr, PlRLazyFrame, PlRSeries, RPolarsErr};
@@ -824,6 +825,14 @@ impl TryFrom<&str> for Wrap<MaintainOrderJoin> {
             _ => return Err("unreachable".to_string()),
         };
         Ok(Wrap(parsed))
+    }
+}
+
+impl TryFrom<&str> for Wrap<Engine> {
+    type Error = savvy::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Engine::from_str(value).map_err(Into::into).map(Wrap)
     }
 }
 


### PR DESCRIPTION
This argument should eventually be exposed to functions that internally call `collect`, but at this point the new streaming engine has not been activated and decisions regarding API design have not yet been made (#260), so for now it will only be added to `collect()`.