### PR TITLE
feat!: Change the default value of `as_series` of `as.list` S3 methods

### DIFF
--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -25,7 +25,7 @@ names.polars_data_frame <- function(x) x$columns
 #' @param x A polars object
 #' @param ... Passed to [as_polars_df()].
 #' @param as_series Whether to convert each column to an [R vector][vector] or a [Series].
-#' If `TRUE`, return a list of [Series], otherwise a list of [vectors][vector] (default).
+#' If `TRUE` (default), return a list of [Series], otherwise a list of [vectors][vector].
 #' @return A [list]
 #' @seealso
 #' - [`<DataFrame>$get_columns()`][dataframe__get_columns]
@@ -42,7 +42,7 @@ names.polars_data_frame <- function(x) x$columns
 as.list.polars_data_frame <- function(
   x,
   ...,
-  as_series = FALSE,
+  as_series = TRUE,
   uint8 = c("integer", "raw"),
   int64 = c("double", "character", "integer", "integer64"),
   date = c("Date", "IDate"),

--- a/man/s3-as.list.Rd
+++ b/man/s3-as.list.Rd
@@ -8,7 +8,7 @@
 \method{as.list}{polars_data_frame}(
   x,
   ...,
-  as_series = FALSE,
+  as_series = TRUE,
   uint8 = c("integer", "raw"),
   int64 = c("double", "character", "integer", "integer64"),
   date = c("Date", "IDate"),
@@ -23,7 +23,7 @@
 \method{as.list}{polars_lazy_frame}(
   x,
   ...,
-  as_series = FALSE,
+  as_series = TRUE,
   uint8 = c("integer", "raw"),
   int64 = c("double", "character", "integer", "integer64"),
   date = c("Date", "IDate"),
@@ -41,7 +41,7 @@
 \item{...}{Passed to \code{\link[=as_polars_df]{as_polars_df()}}.}
 
 \item{as_series}{Whether to convert each column to an \link[=vector]{R vector} or a \link{Series}.
-If \code{TRUE}, return a list of \link{Series}, otherwise a list of \link[=vector]{vectors} (default).}
+If \code{TRUE} (default), return a list of \link{Series}, otherwise a list of \link[=vector]{vectors}.}
 
 \item{uint8}{Determine how to convert Polars' UInt8 type values to R type.
 One of the followings:

--- a/tests/testthat/test-expr-datetime.R
+++ b/tests/testthat/test-expr-datetime.R
@@ -327,7 +327,7 @@ test_that("second, milli, micro, nano", {
     df$select("second"),
     pl$DataFrame(
       !!!df$select(second = "date") |>
-        as.list() |>
+        as.list(as_series = FALSE) |>
         lapply(format, "%S") |>
         lapply(as.numeric)
     )$cast(pl$Int8)
@@ -647,7 +647,7 @@ test_that("dt$replace_time_zone() works", {
     pl$col("London")$dt$replace_time_zone("Europe/Amsterdam")$alias("Amsterdam")
   )
 
-  r_vals <- as.list(df)
+  r_vals <- as.list(df, as_series = FALSE)
 
   expect_equal(
     r_vals |> lapply(attr, "tz"),

--- a/tests/testthat/test-expr-expr.R
+++ b/tests/testthat/test-expr-expr.R
@@ -1224,9 +1224,8 @@ test_that("std var", {
     )
   )
   expect_equal(
-    pl$select(pl$lit(1:5)$std(3) != sd(1:5)) |>
-      as.list(),
-    list(literal = TRUE)
+    pl$select(pl$lit(1:5)$std(3) != sd(1:5)),
+    pl$select(literal = TRUE)
   )
 
   expect_equal(
@@ -1240,9 +1239,8 @@ test_that("std var", {
     )
   )
   expect_equal(
-    pl$select(pl$lit(1:5)$var(3) != var(1:5)) |>
-      as.list(),
-    list(literal = TRUE)
+    pl$select(pl$lit(1:5)$var(3) != var(1:5)),
+    pl$select(literal = TRUE)
   )
 
   # trigger u8 conversion errors
@@ -1562,9 +1560,9 @@ test_that("hash", {
   )
 
   expect_false(
-    identical(as.list(hash_values1), as.list(hash_values2))
+    identical(as.list(hash_values1, as_series = FALSE), as.list(hash_values2, as_series = FALSE))
   )
-  expect_false(anyDuplicated(as.list(hash_values1)$Sepal.Width) > 0)
+  expect_false(anyDuplicated(as.list(hash_values1, as_series = FALSE)$Sepal.Width) > 0)
 })
 
 test_that("reinterpret", {


### PR DESCRIPTION
It would be worth changing the default argument so that `as.list(x) |> as_polars_df()` can restore the original DataFrame.

This would be useful when we want to apply some R function on a column-by-column basis in combination with `purrr::map`, etc.