### PR TITLE
ci: Miniaturization of the `R CMD check` test matrix

### DIFF
--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -54,7 +54,6 @@ jobs:
         os:
           - ubuntu-latest
         r:
-          - release
           - devel
           - "4.3"
     steps:


### PR DESCRIPTION
I think the oldest and newest versions supported here are sufficient.