### PR TITLE
fix: The `drop` argument of `[.polars_data_frame` works correctly for more cases

### DIFF
--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -286,7 +286,9 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
     )
   }
 
-  if (!is_null(j)) {
+  to_select <- if (is_null(j)) {
+    cols
+  } else {
     # Can be:
     # - numeric but cannot beyond the number of columns, and cannot mix positive
     #   and negative indices
@@ -325,14 +327,14 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
           )
         )
       }
-      to_select <- cols[j]
+      cols[j]
     } else if (is_bare_character(j)) {
-      to_select <- j
+      j
     } else if (is_bare_logical(j)) {
       if (length(j) == 1) {
-        to_select <- cols
+        cols
       } else if (length(j) == length(cols)) {
-        to_select <- cols[j]
+        cols[j]
       } else {
         abort(
           c(
@@ -347,17 +349,11 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
         )
       }
     }
-
-    # Don't do this too early because x[, TRUE, drop = TRUE] mustn't drop if
-    # x has more than 1 column
-    if (length(to_select) > 1) {
-      drop <- FALSE
-    }
-
-    x <- x$select(to_select)
   }
 
-  if (isTRUE(drop)) {
+  x <- x$select(to_select)
+
+  if (isTRUE(drop) && length(to_select) == 1L) {
     x$get_columns()[[1]]
   } else {
     x

--- a/tests/testthat/test-dataframe-s3-base.R
+++ b/tests/testthat/test-dataframe-s3-base.R
@@ -154,3 +154,17 @@ test_that("`[` operator works to subset both rows and columns", {
   expect_identical(test[1:2, "a"], pl$DataFrame(a = 1:2))
   expect_identical(test[TRUE, "a"], pl$DataFrame(a = 1:3))
 })
+
+test_that("`[`'s drop argument works correctly", {
+  test <- pl$DataFrame(a = 1:3, b = 4:6, c = 7:9)
+
+  expect_equal(
+    test[1, , drop = TRUE],
+    pl$DataFrame(a = 1L, b = 4L, c = 7L)
+  )
+  # TODO: polars drops the row if columns are dropped
+  expect_equal(
+    test[1, character(), drop = TRUE],
+    as_polars_df(NULL)
+  )
+})


### PR DESCRIPTION
Part of #328

A follow up for #330