### PR TITLE
refactor: Remove unused `rlang::` namespace prefix and makes linter happy

### DIFF
--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -183,7 +183,7 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
     )
   }
 
-  if (is_bare_numeric(i) && !rlang::is_integerish(i)) {
+  if (is_bare_numeric(i) && !is_integerish(i)) {
     abort(
       c(
         sprintf("Can't subset rows with `%s`.", deparse(i_arg)),
@@ -262,7 +262,7 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
     )
   }
 
-  if (is_bare_numeric(j) && !rlang::is_integerish(j)) {
+  if (is_bare_numeric(j) && !is_integerish(j)) {
     abort(
       c(
         sprintf("Can't subset columns with `%s`.", deparse(j_arg)),

--- a/tests/testthat/test-dataframe-s3-base.R
+++ b/tests/testthat/test-dataframe-s3-base.R
@@ -73,7 +73,9 @@ test_that("`[` operator works to subset columns only", {
 
   ### Empty args
   expect_identical(test[], test)
-  expect_identical(test[,], test)
+  # fmt: skip
+  # <https://github.com/posit-dev/air/issues/330>
+  expect_identical(test[, ], test)
 
   expect_snapshot(test[mean], error = TRUE)
   expect_snapshot(test[list(1)], error = TRUE)


### PR DESCRIPTION
A follow up for #330