### PR TITLE
fix!: Extract (`[`) for DataFrame handles `NULL`, `FALSE` and column names correctly

### DIFF
--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -326,14 +326,10 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
     if (length(non_existent_cols) > 0L) {
       abort(
         c(
-          `!` = "Can't subset columns that don't exist.",
+          "Can't subset columns that don't exist.",
           x = sprintf(
             "Columns %s don't exist.",
             oxford_comma(sprintf("`%s`", non_existent_cols), final = "and")
-          ),
-          i = sprintf(
-            "Available columns are %s.",
-            oxford_comma(sprintf("`%s`", cols), final = "and")
           )
         )
       )

--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -126,26 +126,23 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
 # https://tibble.tidyverse.org/articles/invariants.html#column-subsetting
 # TODO: add document
 #' @export
-`[.polars_data_frame` <- function(x, i, j, drop = FALSE) {
+`[.polars_data_frame` <- function(x, i, j, ..., drop = FALSE) {
+  # taken from tibble:::`[.tbl_df`
   cols <- names(x)
 
   # useful for error messages below
   i_arg <- substitute(i)
   j_arg <- substitute(j)
 
-  # taken from tibble:::`[.tbl_df`
   if (missing(i)) {
-    i <- NULL
+    i <- TRUE
     i_arg <- NULL
-  } else if (is_null(i)) {
-    i <- integer()
   }
   if (missing(j)) {
-    j <- NULL
+    j <- cols
     j_arg <- NULL
-  } else if (is_null(j)) {
-    j <- integer()
   }
+
   n_real_args <- nargs() - !missing(drop)
   if (n_real_args <= 2L) {
     if (!missing(drop)) {
@@ -157,20 +154,23 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
       )
       drop <- FALSE
     }
-    j <- i
-    i <- NULL
+    j <- if (!missing(i)) {
+      i
+    } else {
+      cols
+    }
+    i <- TRUE
     j_arg <- i_arg
     i_arg <- NULL
   }
 
-  if (is_null(i) && is_null(j)) {
-    return(x)
-  }
+  i <- i %||% FALSE
+  j <- j %||% character()
 
   #### Rows -----------------------------------------------------
 
   # check accepted types for subsetting rows
-  if (!is_null(i) && !is_bare_character(i) && !is_bare_numeric(i) && !is_bare_logical(i)) {
+  if (!is_bare_character(i) && !is_bare_numeric(i) && !is_bare_logical(i)) {
     abort(
       c(
         sprintf("Can't subset rows with `%s`.", deparse(i_arg)),
@@ -192,64 +192,60 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
     )
   }
 
-  if (!is_null(i)) {
-    # If logical, `i` must be of length 1 or number of rows
-    if (is_bare_logical(i)) {
-      if (length(i) == 1 && isTRUE(i)) {
-        idx <- rep_len(TRUE, x$height)
-      } else if (length(i) == x$height) {
-        idx <- i
-      } else {
+  # If logical, `i` must be of length 1 or number of rows
+  if (is_bare_logical(i)) {
+    if (length(i) %in% c(1L, x$height)) {
+      idx <- i
+    } else {
+      abort(
+        c(
+          `!` = sprintf("Can't subset rows with `%s`.", deparse(i_arg)),
+          i = sprintf(
+            "Logical subscript `%s` must be size 1 or %s, not %s",
+            deparse(i_arg),
+            x$height,
+            length(i)
+          )
+        )
+      )
+    }
+  } else {
+    # Negative indices -> drop those rows
+    # Do not accept mixing negative and positive indices
+    if (is_bare_numeric(i)) {
+      if (all(i < 0)) {
+        i <- setdiff(seq_len(x$height), abs(i))
+      } else if (any(i < 0) && any(i > 0)) {
+        sign_start <- sign(i[i != 0])[1]
+        loc <- if (sign_start == -1) {
+          which(sign(i) == 1)[1]
+        } else if (sign_start == 1) {
+          which(sign(i) == -1)[1]
+        }
         abort(
           c(
             `!` = sprintf("Can't subset rows with `%s`.", deparse(i_arg)),
+            x = "Negative and positive locations can't be mixed.",
             i = sprintf(
-              "Logical subscript `%s` must be size 1 or %s, not %s",
+              "Subscript `%s` has a %s value at location %s.",
               deparse(i_arg),
-              x$height,
-              length(i)
+              if (sign_start == 1) "negative" else "positive",
+              loc
             )
           )
         )
       }
-    } else {
-      # Negative indices -> drop those rows
-      # Do not accept mixing negative and positive indices
-      if (is_bare_numeric(i)) {
-        if (all(i < 0)) {
-          i <- setdiff(seq_len(x$height), abs(i))
-        } else if (any(i < 0) && any(i > 0)) {
-          sign_start <- sign(i[i != 0])[1]
-          loc <- if (sign_start == -1) {
-            which(sign(i) == 1)[1]
-          } else if (sign_start == 1) {
-            which(sign(i) == -1)[1]
-          }
-          abort(
-            c(
-              `!` = sprintf("Can't subset rows with `%s`.", deparse(i_arg)),
-              x = "Negative and positive locations can't be mixed.",
-              i = sprintf(
-                "Subscript `%s` has a %s value at location %s.",
-                deparse(i_arg),
-                if (sign_start == 1) "negative" else "positive",
-                loc
-              )
-            )
-          )
-        }
-      }
-
-      idx <- seq_len(x$height) %in% i
     }
 
-    x <- x$filter(pl$lit(idx))
+    idx <- seq_len(x$height) %in% i
   }
+
+  x <- x$filter(pl$lit(idx))
 
   #### Columns -----------------------------------------------------
 
   # check accepted types for subsetting columns
-  if (!is_null(j) && !is_bare_character(j) && !is_bare_numeric(j) && !is_bare_logical(j)) {
+  if (!is_bare_character(j) && !is_bare_numeric(j) && !is_bare_logical(j)) {
     abort(
       c(
         sprintf("Can't subset columns with `%s`.", deparse(j_arg)),
@@ -286,74 +282,68 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
     )
   }
 
-  to_select <- if (is_null(j)) {
-    cols
-  } else {
-    # Can be:
-    # - numeric but cannot beyond the number of columns, and cannot mix positive
-    #   and negative indices
-    # - logical but must be of length 1 or number of columns
-    # - character
-    if (is_bare_numeric(j)) {
-      wrong_locs <- j[j > length(cols)]
-      if (length(wrong_locs) > 0) {
-        abort(
-          c(
-            "Can't subset columns past the end.",
-            i = sprintf("Location(s) %s don't exist.", oxford_comma(wrong_locs, final = "and")),
-            i = sprintf("There are only %s columns.", length(cols))
+  # Can be:
+  # - numeric but cannot beyond the number of columns, and cannot mix positive
+  #   and negative indices
+  # - logical but must be of length 1 or number of columns
+  # - character
+  to_select <- if (is_bare_numeric(j)) {
+    wrong_locs <- j[j > length(cols)]
+    if (length(wrong_locs) > 0) {
+      abort(
+        c(
+          "Can't subset columns past the end.",
+          i = sprintf("Location(s) %s don't exist.", oxford_comma(wrong_locs, final = "and")),
+          i = sprintf("There are only %s columns.", length(cols))
+        )
+      )
+    }
+    if (all(j < 0)) {
+      j <- setdiff(seq_len(length(cols)), abs(j))
+    } else if (any(j < 0) && any(j > 0)) {
+      sign_start <- sign(j[j != 0])[1]
+      loc <- if (sign_start == -1) {
+        which(sign(j) == 1)[1]
+      } else if (sign_start == 1) {
+        which(sign(j) == -1)[1]
+      }
+      abort(
+        c(
+          `!` = sprintf("Can't subset columns with `%s`.", deparse(j_arg)),
+          x = "Negative and positive locations can't be mixed.",
+          i = sprintf(
+            "Subscript `%s` has a %s value at location %s.",
+            deparse(j_arg),
+            if (sign_start == 1) "negative" else "positive",
+            loc
           )
         )
-      }
-      if (all(j < 0)) {
-        j <- setdiff(seq_len(length(cols)), abs(j))
-      } else if (any(j < 0) && any(j > 0)) {
-        sign_start <- sign(j[j != 0])[1]
-        loc <- if (sign_start == -1) {
-          which(sign(j) == 1)[1]
-        } else if (sign_start == 1) {
-          which(sign(j) == -1)[1]
-        }
-        abort(
-          c(
-            `!` = sprintf("Can't subset columns with `%s`.", deparse(j_arg)),
-            x = "Negative and positive locations can't be mixed.",
-            i = sprintf(
-              "Subscript `%s` has a %s value at location %s.",
-              deparse(j_arg),
-              if (sign_start == 1) "negative" else "positive",
-              loc
-            )
-          )
-        )
-      }
+      )
+    }
+    cols[j]
+  } else if (is_bare_character(j)) {
+    j
+  } else if (is_bare_logical(j)) {
+    if (length(j) %in% c(1L, length(cols))) {
       cols[j]
-    } else if (is_bare_character(j)) {
-      j
-    } else if (is_bare_logical(j)) {
-      if (length(j) == 1) {
-        cols
-      } else if (length(j) == length(cols)) {
-        cols[j]
-      } else {
-        abort(
-          c(
-            `!` = sprintf("Can't subset columns with `%s`.", deparse(j_arg)),
-            i = sprintf(
-              "Logical subscript `%s` must be size 1 or %s, not %s",
-              deparse(j_arg),
-              length(cols),
-              length(j)
-            )
+    } else {
+      abort(
+        c(
+          `!` = sprintf("Can't subset columns with `%s`.", deparse(j_arg)),
+          i = sprintf(
+            "Logical subscript `%s` must be size 1 or %s, not %s",
+            deparse(j_arg),
+            length(cols),
+            length(j)
           )
         )
-      }
+      )
     }
   }
 
   x <- x$select(to_select)
 
-  if (isTRUE(drop) && length(to_select) == 1L) {
+  if (isTRUE(drop) && ncol(x) == 1L) {
     x$get_columns()[[1]]
   } else {
     x

--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -286,7 +286,7 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
   # - numeric but cannot beyond the number of columns, and cannot mix positive
   #   and negative indices
   # - logical but must be of length 1 or number of columns
-  # - character
+  # - character, should not contain non-existing column names
   to_select <- if (is_bare_numeric(j)) {
     wrong_locs <- j[j > length(cols)]
     if (length(wrong_locs) > 0) {
@@ -322,7 +322,24 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
     }
     cols[j]
   } else if (is_bare_character(j)) {
-    j
+    non_existent_cols <- setdiff(j, cols)
+    if (length(non_existent_cols) > 0L) {
+      abort(
+        c(
+          `!` = "Can't subset columns that don't exist.",
+          x = sprintf(
+            "Columns %s don't exist.",
+            oxford_comma(sprintf("`%s`", non_existent_cols), final = "and")
+          ),
+          i = sprintf(
+            "Available columns are %s.",
+            oxford_comma(sprintf("`%s`", cols), final = "and")
+          )
+        )
+      )
+    } else {
+      j
+    }
   } else if (is_bare_logical(j)) {
     if (length(j) %in% c(1L, length(cols))) {
       cols[j]

--- a/tests/testthat/_snaps/dataframe-s3-base.md
+++ b/tests/testthat/_snaps/dataframe-s3-base.md
@@ -40,6 +40,26 @@
 ---
 
     Code
+      test[c("foo", "a", "bar", "baz")]
+    Condition
+      Error in `test[c("foo", "a", "bar", "baz")]`:
+      ! Can't subset columns that don't exist.
+      x Columns `foo`, `bar`, and `baz` don't exist.
+      i Available columns are `a`, `b`, and `c`.
+
+---
+
+    Code
+      test["*"]
+    Condition
+      Error in `test["*"]`:
+      ! Can't subset columns that don't exist.
+      x Columns `*` don't exist.
+      i Available columns are `a`, `b`, and `c`.
+
+---
+
+    Code
       test[mean]
     Condition
       Error in `test[mean]`:

--- a/tests/testthat/_snaps/dataframe-s3-base.md
+++ b/tests/testthat/_snaps/dataframe-s3-base.md
@@ -45,7 +45,6 @@
       Error in `test[c("foo", "a", "bar", "baz")]`:
       ! Can't subset columns that don't exist.
       x Columns `foo`, `bar`, and `baz` don't exist.
-      i Available columns are `a`, `b`, and `c`.
 
 ---
 
@@ -55,7 +54,6 @@
       Error in `test["*"]`:
       ! Can't subset columns that don't exist.
       x Columns `*` don't exist.
-      i Available columns are `a`, `b`, and `c`.
 
 ---
 

--- a/tests/testthat/test-dataframe-s3-base.R
+++ b/tests/testthat/test-dataframe-s3-base.R
@@ -172,4 +172,10 @@ test_that("`[`'s drop argument works correctly", {
     test[1, character(), drop = TRUE],
     as_polars_df(NULL)
   )
+
+  # drop should be named
+  expect_equal(
+    test[, "a", TRUE],
+    pl$DataFrame(a = 1:3)
+  )
 })

--- a/tests/testthat/test-dataframe-s3-base.R
+++ b/tests/testthat/test-dataframe-s3-base.R
@@ -53,10 +53,8 @@ test_that("`[` operator works to subset columns only", {
   expect_identical(test[, "a", drop = TRUE], pl$Series("a", 1:3))
   expect_identical(test[c("a", "b")], pl$DataFrame(a = 1:3, b = 4:6))
   expect_identical(test[, c("a", "b"), drop = TRUE], pl$DataFrame(a = 1:3, b = 4:6))
-  expect_error(
-    test[c("a", "foo")],
-    "not found: foo"
-  )
+  expect_snapshot(test[c("foo", "a", "bar", "baz")], error = TRUE)
+  expect_snapshot(test["*"], error = TRUE)
 
   ### Logical values
   expect_identical(test[TRUE], test)

--- a/tests/testthat/test-dataframe-s3-base.R
+++ b/tests/testthat/test-dataframe-s3-base.R
@@ -60,6 +60,7 @@ test_that("`[` operator works to subset columns only", {
 
   ### Logical values
   expect_identical(test[TRUE], test)
+  expect_identical(test[FALSE], pl$DataFrame())
   expect_identical(test[c(TRUE, TRUE, FALSE)], pl$DataFrame(a = 1:3, b = 4:6))
   expect_error(
     test[c(TRUE, FALSE)],
@@ -126,6 +127,7 @@ test_that("`[` operator works to subset rows only", {
 
   ### Logical
   expect_identical(test[TRUE, ], test)
+  expect_identical(test[FALSE, ], test$clear())
   expect_identical(
     test[c(TRUE, TRUE, FALSE), ],
     pl$DataFrame(a = 1:2, b = 4:5, c = 7:8)
@@ -155,6 +157,9 @@ test_that("`[` operator works to subset both rows and columns", {
   test <- pl$DataFrame(a = 1:3, b = 4:6, c = 7:9)
   expect_identical(test[1:2, "a"], pl$DataFrame(a = 1:2))
   expect_identical(test[TRUE, "a"], pl$DataFrame(a = 1:3))
+  expect_identical(test[NULL, "a"], test$select("a")$clear())
+  # TODO: polars drops the row if columns are dropped
+  expect_identical(test[1, NULL], pl$DataFrame())
 })
 
 test_that("`[`'s drop argument works correctly", {


### PR DESCRIPTION
Part of #328

A follow up for #330