### PR TITLE
feat: Extract (`[`) for DataFrame handles row index correctly

### DIFF
--- a/R/000-wrappers.R
+++ b/R/000-wrappers.R
@@ -422,6 +422,13 @@ class(`PlRChainedWhen`) <- c("PlRChainedWhen__bundle", "savvy_neopolars__sealed"
   }
 }
 
+`PlRDataFrame_gather_with_series` <- function(self) {
+  function(`indices`) {
+    `indices` <- .savvy_extract_ptr(`indices`, "PlRSeries")
+    .savvy_wrap_PlRDataFrame(.Call(savvy_PlRDataFrame_gather_with_series__impl, `self`, `indices`))
+  }
+}
+
 `PlRDataFrame_get_column` <- function(self) {
   function(`name`) {
     .savvy_wrap_PlRSeries(.Call(savvy_PlRDataFrame_get_column__impl, `self`, `name`))
@@ -632,6 +639,7 @@ class(`PlRChainedWhen`) <- c("PlRChainedWhen__bundle", "savvy_neopolars__sealed"
   e$`columns` <- `PlRDataFrame_columns`(ptr)
   e$`dtypes` <- `PlRDataFrame_dtypes`(ptr)
   e$`equals` <- `PlRDataFrame_equals`(ptr)
+  e$`gather_with_series` <- `PlRDataFrame_gather_with_series`(ptr)
   e$`get_column` <- `PlRDataFrame_get_column`(ptr)
   e$`get_column_index` <- `PlRDataFrame_get_column_index`(ptr)
   e$`get_columns` <- `PlRDataFrame_get_columns`(ptr)

--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -229,7 +229,8 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
               n_rows,
               length(i)
             )
-          )
+          ),
+          call = error_env
         )
       }
       seq_len(n_rows)[i]
@@ -260,7 +261,8 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
                     n_na,
                     oxford_comma(which(is.na(i)), final = "and")
                   )
-                )
+                ),
+                call = error_env
               )
             }
             # If all values are NA, i will be used as the index
@@ -286,7 +288,8 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
                 if (sign_start == 1) "negative" else "positive",
                 loc
               )
-            )
+            ),
+            call = error_env
           )
         } else {
           # Positive integer-ish

--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -216,7 +216,10 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
     # If non-NA logical vector, just passing it to $filter() is enough
     x$filter(i)
   } else {
-    # Else, we need to use `select_rows_by_index()` and calculate the indices in R
+    # Else, we need to use `select_rows_by_index()` and calculate the indices in R.
+    # For LazyFrame (n_rows is NA), this branch is unreachable.
+    # So this `seq_len()` should be safe.
+    seq_n_rows <- seq_len(n_rows)
     idx <- if (is_logical(i)) {
       # If logical, `i` must be of length 1 or number of rows
       if (!length(i) %in% c(1L, n_rows)) {
@@ -232,13 +235,10 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
           ),
           call = error_env
         )
+      } else {
+        seq_n_rows[i]
       }
-      seq_len(n_rows)[i]
     } else {
-      # For LazyFrame (n_rows is NA), this branch is unreachable.
-      # So this operation is safe.
-      seq_n_rows <- seq_len(n_rows)
-
       idx <- if (is_character(i)) {
         # Character case
         i

--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -370,9 +370,9 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
         call = error_env
       )
     }
-    if (all(j < 0)) {
+    if (max(j) < 0) {
       j <- setdiff(seq_len(n_cols), abs(j))
-    } else if (any(j < 0) && any(j > 0)) {
+    } else if (min(j) < 0) {
       sign_start <- sign(j[j != 0])[1]
       loc <- if (sign_start == -1) {
         which(sign(j) == 1)[1]

--- a/R/dataframe-s3-base.R
+++ b/R/dataframe-s3-base.R
@@ -247,7 +247,7 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
         # Negative indices -> drop those rows
         # - Do not accept NA values in negative indices
         # - Do not accept mixing negative and positive indices
-        if (all(i < 0, na.rm = TRUE)) {
+        if (suppressWarnings(max(i, na.rm = TRUE) < 0)) {
           n_na <- sum(is.na(i))
           if (n_na > 0) {
             if (n_na < length(i)) {
@@ -270,7 +270,7 @@ tail.polars_data_frame <- function(x, n = 6L, ...) x$tail(n = n)
           } else {
             setdiff(seq_n_rows, abs(i))
           }
-        } else if (any(i < 0, na.rm = TRUE)) {
+        } else if (suppressWarnings(min(i, na.rm = TRUE) < 0)) {
           # Mixing negative and positive indices (Not allowed)
           sign_start <- sign(i[i != 0])[1]
           loc <- if (sign_start == -1) {

--- a/R/utils-getitem.R
+++ b/R/utils-getitem.R
@@ -1,0 +1,4 @@
+select_rows_by_index <- function(df, key) {
+  df$`_df`$gather_with_series(key$`_s`) |>
+    wrap()
+}

--- a/src/init.c
+++ b/src/init.c
@@ -314,6 +314,11 @@ SEXP savvy_PlRDataFrame_equals__impl(SEXP self__, SEXP c_arg__other, SEXP c_arg_
     return handle_result(res);
 }
 
+SEXP savvy_PlRDataFrame_gather_with_series__impl(SEXP self__, SEXP c_arg__indices) {
+    SEXP res = savvy_PlRDataFrame_gather_with_series__ffi(self__, c_arg__indices);
+    return handle_result(res);
+}
+
 SEXP savvy_PlRDataFrame_get_column__impl(SEXP self__, SEXP c_arg__name) {
     SEXP res = savvy_PlRDataFrame_get_column__ffi(self__, c_arg__name);
     return handle_result(res);
@@ -3052,6 +3057,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"savvy_PlRDataFrame_deserialize_binary__impl", (DL_FUNC) &savvy_PlRDataFrame_deserialize_binary__impl, 1},
     {"savvy_PlRDataFrame_dtypes__impl", (DL_FUNC) &savvy_PlRDataFrame_dtypes__impl, 1},
     {"savvy_PlRDataFrame_equals__impl", (DL_FUNC) &savvy_PlRDataFrame_equals__impl, 3},
+    {"savvy_PlRDataFrame_gather_with_series__impl", (DL_FUNC) &savvy_PlRDataFrame_gather_with_series__impl, 2},
     {"savvy_PlRDataFrame_get_column__impl", (DL_FUNC) &savvy_PlRDataFrame_get_column__impl, 2},
     {"savvy_PlRDataFrame_get_column_index__impl", (DL_FUNC) &savvy_PlRDataFrame_get_column_index__impl, 2},
     {"savvy_PlRDataFrame_get_columns__impl", (DL_FUNC) &savvy_PlRDataFrame_get_columns__impl, 1},

--- a/src/rust/api.h
+++ b/src/rust/api.h
@@ -60,6 +60,7 @@ SEXP savvy_PlRDataFrame_columns__ffi(SEXP self__);
 SEXP savvy_PlRDataFrame_deserialize_binary__ffi(SEXP c_arg__data);
 SEXP savvy_PlRDataFrame_dtypes__ffi(SEXP self__);
 SEXP savvy_PlRDataFrame_equals__ffi(SEXP self__, SEXP c_arg__other, SEXP c_arg__null_equal);
+SEXP savvy_PlRDataFrame_gather_with_series__ffi(SEXP self__, SEXP c_arg__indices);
 SEXP savvy_PlRDataFrame_get_column__ffi(SEXP self__, SEXP c_arg__name);
 SEXP savvy_PlRDataFrame_get_column_index__ffi(SEXP self__, SEXP c_arg__name);
 SEXP savvy_PlRDataFrame_get_columns__ffi(SEXP self__);

--- a/src/rust/src/dataframe/general.rs
+++ b/src/rust/src/dataframe/general.rs
@@ -70,6 +70,15 @@ impl PlRDataFrame {
         (out as i32).try_into()
     }
 
+    pub fn gather_with_series(&self, indices: &PlRSeries) -> Result<Self> {
+        let indices = indices.series.idx().map_err(RPolarsErr::from)?;
+        self.df
+            .take(indices)
+            .map_err(RPolarsErr::from)
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
     pub fn transpose(
         &mut self,
         column_names: StringSexp,

--- a/tests/testthat/_snaps/dataframe-s3-base.md
+++ b/tests/testthat/_snaps/dataframe-s3-base.md
@@ -145,6 +145,24 @@
 ---
 
     Code
+      test[c(TRUE, FALSE), ]
+    Condition
+      Error in `test[c(TRUE, FALSE), ]`:
+      ! Can't subset rows with `c(TRUE, FALSE)`.
+      i Logical subscript `c(TRUE, FALSE)` must be size 1 or 3, not 2
+
+---
+
+    Code
+      test[c(NA, FALSE), ]
+    Condition
+      Error in `test[c(NA, FALSE), ]`:
+      ! Can't subset rows with `c(NA, FALSE)`.
+      i Logical subscript `c(NA, FALSE)` must be size 1 or 3, not 2
+
+---
+
+    Code
       test[mean, ]
     Condition
       Error in `test[mean, ]`:

--- a/tests/testthat/_snaps/dataframe-s3-base.md
+++ b/tests/testthat/_snaps/dataframe-s3-base.md
@@ -106,6 +106,16 @@
 # `[` operator works to subset rows only
 
     Code
+      test[c(-1, NA), ]
+    Condition
+      Error in `test[c(-1, NA), ]`:
+      ! Can't subset rows with `c(-1, NA)`.
+      x Negative locations can't have missing values.
+      i Subscript `c(-1, NA)` has 1 missing values at location 2.
+
+---
+
+    Code
       test[-2:1, ]
     Condition
       Error in `test[-2:1, ]`:

--- a/tests/testthat/test-dataframe-s3-base.R
+++ b/tests/testthat/test-dataframe-s3-base.R
@@ -95,15 +95,31 @@ test_that("`[` operator works to subset rows only", {
     test[1:2, ],
     pl$DataFrame(a = 1:2, b = 4:5, c = 7:8)
   )
-  # TODO
-  # expect_identical(
-  #   test[c(1, 10), ],
-  #   pl$DataFrame(a = c(1L, NA_integer_), b = c(4L, NA_integer_), c = c(7L, NA_integer_))
-  # )
+  expect_identical(
+    test[c(1, 10), ],
+    pl$DataFrame(a = c(1L, NA_integer_), b = c(4L, NA_integer_), c = c(7L, NA_integer_))
+  )
+  expect_identical(
+    test[c(2, 1, 1), ],
+    pl$DataFrame(a = c(2L, 1L, 1L), b = c(5L, 4L, 4L), c = c(8L, 7L, 7L))
+  )
+  expect_identical(
+    test[c(2, 10000, 1), ],
+    pl$DataFrame(a = c(2L, NA_integer_, 1L), b = c(5L, NA_integer_, 4L), c = c(8L, NA_integer_, 7L))
+  )
+  expect_identical(
+    test[c(2, NA), ],
+    pl$DataFrame(a = c(2L, NA_integer_), b = c(5L, NA_integer_), c = c(8L, NA_integer_))
+  )
   expect_identical(
     test[-2:-1, ],
     pl$DataFrame(a = 3L, b = 6L, c = 9L)
   )
+  expect_identical(
+    test[NA_integer_, ],
+    pl$DataFrame(a = NA_integer_, b = NA_integer_, c = NA_integer_)
+  )
+  expect_snapshot(test[c(-1, NA), ], error = TRUE)
   expect_snapshot(test[-2:1, ], error = TRUE)
   expect_snapshot(test[1:-2, ], error = TRUE)
   expect_snapshot(test[1.5, ], error = TRUE)
@@ -117,11 +133,10 @@ test_that("`[` operator works to subset rows only", {
     test[c("1", "2"), ],
     pl$DataFrame(a = 1:2, b = 4:5, c = 7:8)
   )
-  # TODO
-  # expect_identical(
-  #   test["foo", ],
-  #   pl$DataFrame(a = NA_integer_, b = NA_integer_, c = NA_integer_)
-  # )
+  expect_identical(
+    test["foo", ],
+    pl$DataFrame(a = NA_integer_, b = NA_integer_, c = NA_integer_)
+  )
 
   ### Logical
   expect_identical(test[TRUE, ], test)

--- a/tests/testthat/test-dataframe-s3-base.R
+++ b/tests/testthat/test-dataframe-s3-base.R
@@ -145,19 +145,16 @@ test_that("`[` operator works to subset rows only", {
     test[c(TRUE, TRUE, FALSE), ],
     pl$DataFrame(a = 1:2, b = 4:5, c = 7:8)
   )
-  # TODO
-  # expect_identical(
-  #   test[NA, ],
-  #   pl$DataFrame(a = rep(NA, 3), b = rep(NA, 3), c = rep(NA, 3))
-  # )
-  # expect_identical(
-  #   test[NA_integer_, ],
-  #   pl$DataFrame(a = NA, b = NA, c = NA)
-  # )
-  expect_error(
-    test[c(TRUE, FALSE), ],
-    "must be size 1 or 3, not 2"
+  expect_identical(
+    test[NA, ],
+    pl$DataFrame(a = rep(NA_integer_, 3), b = rep(NA_integer_, 3), c = rep(NA_integer_, 3))
   )
+  expect_identical(
+    test[c(FALSE, NA, TRUE), ],
+    pl$DataFrame(a = c(NA_integer_, 3L), b = c(NA_integer_, 6L), c = c(NA_integer_, 9L))
+  )
+  expect_snapshot(test[c(TRUE, FALSE), ], error = TRUE)
+  expect_snapshot(test[c(NA, FALSE), ], error = TRUE)
 
   expect_snapshot(test[mean, ], error = TRUE)
   expect_snapshot(test[list(1), ], error = TRUE)


### PR DESCRIPTION
Close #328

Previous implementations did not work correctly in the following cases:

``` r
tibble::tibble(a = 1:3)[c(1, NA, 1, 3), ]
#> # A tibble: 4 × 1
#>       a
#>   <int>
#> 1     1
#> 2    NA
#> 3     1
#> 4     3
```

<sup>Created on 2025-05-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>