### PR TITLE
chore: Remove the `Additional_repositories` field to reduce build time on R-universe arm64 ubuntu

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Suggests:
     tibble,
     vctrs,
     withr
-Additional_repositories: https://community.r-multiverse.org
 Config/Needs/dev: devtools, lifecycle, readr, glue
 Config/Needs/lint: fs, lintr
 Config/Needs/website: etiennebacher/altdoc, future.apply


### PR DESCRIPTION
This was originally introduced as a countermeasure to the slow build of the `arrow` package from CRAN, but was no longer necessary since the `arrow` package was built faster on R-universe with subsequent CRAN releases.