### PR TITLE
fix: `describe()` on DataFrame includes 50%

### DIFF
--- a/R/dataframe-frame.R
+++ b/R/dataframe-frame.R
@@ -2261,7 +2261,7 @@ dataframe__unstack <- function(
 #'   interpolation = "linear"
 #' )
 dataframe__describe <- function(
-  percentiles = c(0.25, 0.75),
+  percentiles = c(0.25, 0.5, 0.75),
   ...,
   interpolation = c("nearest", "higher", "lower", "midpoint", "linear")
 ) {

--- a/man/dataframe__describe.Rd
+++ b/man/dataframe__describe.Rd
@@ -5,7 +5,7 @@
 \title{Summary statistics for a DataFrame.}
 \usage{
 dataframe__describe(
-  percentiles = c(0.25, 0.75),
+  percentiles = c(0.25, 0.5, 0.75),
   ...,
   interpolation = c("nearest", "higher", "lower", "midpoint", "linear")
 )

--- a/tests/testthat/_snaps/lazyframe-frame.md
+++ b/tests/testthat/_snaps/lazyframe-frame.md
@@ -134,7 +134,7 @@
     Code
       df$describe()
     Output
-      shape: (8, 6)
+      shape: (9, 6)
       ┌────────────┬──────────┬────────┬─────────────────────────┬──────┬──────┐
       │ statistic  ┆ float    ┆ string ┆ date                    ┆ cat  ┆ bool │
       │ ---        ┆ ---      ┆ ---    ┆ ---                     ┆ ---  ┆ ---  │
@@ -146,6 +146,7 @@
       │ std        ┆ 0.353553 ┆ null   ┆ null                    ┆ null ┆ null │
       │ min        ┆ 1.5      ┆ a      ┆ 2024-01-20              ┆ zz   ┆ 0.0  │
       │ 25%        ┆ 1.5      ┆ null   ┆ 2024-01-20              ┆ null ┆ null │
+      │ 50%        ┆ 2.0      ┆ null   ┆ 2024-01-21              ┆ null ┆ null │
       │ 75%        ┆ 2.0      ┆ null   ┆ 2024-01-21              ┆ null ┆ null │
       │ max        ┆ 2.0      ┆ b      ┆ 2024-01-21              ┆ a    ┆ 1.0  │
       └────────────┴──────────┴────────┴─────────────────────────┴──────┴──────┘
@@ -217,7 +218,7 @@
     Code
       df$select(pl$col("cat")$cast(pl$Categorical("lexical")))$describe()
     Output
-      shape: (8, 2)
+      shape: (9, 2)
       ┌────────────┬──────┐
       │ statistic  ┆ cat  │
       │ ---        ┆ ---  │
@@ -229,6 +230,7 @@
       │ std        ┆ null │
       │ min        ┆ a    │
       │ 25%        ┆ null │
+      │ 50%        ┆ null │
       │ 75%        ┆ null │
       │ max        ┆ zz   │
       └────────────┴──────┘


### PR DESCRIPTION
Fixes #355 

This was only a mistake for DataFrame, not LazyFrame.