### PR TITLE
feat: Register `mirai` serialization config automatically

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Suggests:
     ggplot2,
     hms,
     jsonlite,
+    mirai (>= 2.3.0),
     nanoarrow (>= 0.6.0),
     patrick (>= 0.3.0),
     testthat (>= 3.0.0),

--- a/R/integration-mirai.R
+++ b/R/integration-mirai.R
@@ -1,0 +1,18 @@
+# Taken from the glue package's knitr integration
+# https://github.com/tidyverse/glue/blob/a3f80d678274ef634c10c2cb094c939b1543222a/R/zzz.R#L4-L11
+
+register_mirai_serial <- function() {
+  mirai::register_serial(
+    c("polars_data_frame", "polars_lazy_frame", "polars_series"),
+    sfunc = list(\(x) x$serialize(), \(x) x$serialize(), \(x) x$serialize()),
+    ufunc = list(pl$deserialize_df, pl$deserialize_lf, pl$deserialize_series)
+  )
+}
+
+on_load({
+  if (isNamespaceLoaded("mirai")) {
+    register_mirai_serial()
+  } else {
+    setHook(packageEvent("mirai", "onLoad"), function(...) register_mirai_serial())
+  }
+})


### PR DESCRIPTION
Related to #301

Thanks to r-lib/mirai#280, we no longer does not need to register mirai serializing config by hand.

``` r
library(neopolars)

mirai::daemons(4)
#> [1] 4

pl$DataFrame(a = 1, b = 2, c = 3, d = 4)$cast(pl$Int128) |>
  as.list() |>
  mirai::mirai_map(\(s) {
    s * 2L
  }) |>
  _[] |>
  as_polars_df()
#> shape: (1, 4)
#> ┌──────┬──────┬──────┬──────┐
#> │ a    ┆ b    ┆ c    ┆ d    │
#> │ ---  ┆ ---  ┆ ---  ┆ ---  │
#> │ i128 ┆ i128 ┆ i128 ┆ i128 │
#> ╞══════╪══════╪══════╪══════╡
#> │ 2    ┆ 4    ┆ 6    ┆ 8    │
#> └──────┴──────┴──────┴──────┘
```

<sup>Created on 2025-05-30 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>