### PR TITLE
perf: Replace `is_installed()` with `requireNamespace()` when checking packages called by `<series>$to_r_vector()`

### DIFF
--- a/R/series-to_r_vector.R
+++ b/R/series-to_r_vector.R
@@ -329,29 +329,29 @@ series__to_r_vector <- function(
 }
 
 is_vctrs_installed <- function() {
-  is_installed("vctrs")
+  requireNamespace("vctrs", quietly = TRUE)
 }
 
 is_blob_installed <- function() {
-  is_installed("blob")
+  requireNamespace("blob", quietly = TRUE)
 }
 
 is_hms_installed <- function() {
-  is_installed("hms")
+  requireNamespace("hms", quietly = TRUE)
 }
 
 is_bit64_installed <- function() {
-  is_installed("bit64")
+  requireNamespace("bit64", quietly = TRUE)
 }
 
 is_datatable_installed <- function() {
-  is_installed("data.table")
+  requireNamespace("data.table", quietly = TRUE)
 }
 
 is_tibble_installed <- function() {
-  is_installed("tibble")
+  requireNamespace("tibble", quietly = TRUE)
 }
 
 is_clock_installed <- function() {
-  is_installed("clock")
+  requireNamespace("clock", quietly = TRUE)
 }


### PR DESCRIPTION
I notice that `requireNamespace` is faster than `rlang::is_installed` here. (https://github.com/eitsupi/neo-r-polars/pull/363#discussion_r2117369959)

``` r
library(rlang)

bench::mark(
  require_namespace_loaded = requireNamespace("base", quietly = TRUE),
  is_installed_loaded = is_installed("base"), # Needs <https://github.com/r-lib/rlang/pull/1804>
  require_namespace_not_loaded = {
    out <- requireNamespace("hms", quietly = TRUE)
    unloadNamespace("hms") # Clean up
    out
  },
  is_installed_not_loaded = {
    out <- is_installed("hms")
    unloadNamespace("hms") # Clean up
    out
  },
  check = TRUE
)
#> # A tibble: 4 × 6
#>   expression                        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 require_namespace_loaded       1.18µs   1.32µs  634127.         0B    63.4
#> 2 is_installed_loaded            5.11µs   5.67µs  140366.         0B    14.0
#> 3 require_namespace_not_loaded  11.68ms   13.3ms      72.4     910KB     7.00
#> 4 is_installed_not_loaded       13.02ms  14.03ms      69.0     486KB     6.68
```

<sup>Created on 2025-06-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

This is expected to be called many times, so it is replaced to improve performance.