### PR TITLE
refactor: Simplify `as_polars_df.list()`

### DIFF
--- a/man/s3-as_tibble.Rd
+++ b/man/s3-as_tibble.Rd
@@ -47,6 +47,8 @@
 \item \code{"check_unique"}: (default value), no name repair, but check they are
 \code{unique},
 \item \code{"universal"}: Make the names \code{unique} and syntactic
+\item \code{"unique_quiet"}: Same as \code{"unique"}, but "quiet"
+\item \code{"universal_quiet"}: Same as \code{"universal"}, but "quiet"
 \item a function: apply custom name repair (e.g., \code{.name_repair = make.names}
 for names in the style of base R).
 \item A purrr-style anonymous function, see \code{\link[rlang:as_function]{rlang::as_function()}}

--- a/man/s3-as_tibble.Rd
+++ b/man/s3-as_tibble.Rd
@@ -47,8 +47,6 @@
 \item \code{"check_unique"}: (default value), no name repair, but check they are
 \code{unique},
 \item \code{"universal"}: Make the names \code{unique} and syntactic
-\item \code{"unique_quiet"}: Same as \code{"unique"}, but "quiet"
-\item \code{"universal_quiet"}: Same as \code{"universal"}, but "quiet"
 \item a function: apply custom name repair (e.g., \code{.name_repair = make.names}
 for names in the style of base R).
 \item A purrr-style anonymous function, see \code{\link[rlang:as_function]{rlang::as_function()}}


### PR DESCRIPTION
Following https://github.com/eitsupi/neo-r-polars/pull/384#discussion_r2145257484, this removes the use of `suppressWarnings()` and `is.infinite()`.