### PR TITLE
chore: Bump package version and set urls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: polars
 Title: R Bindings for the 'polars' Rust Library
-Version: 0.0.9000.9000
+Version: 0.9000.9000.9000
 Authors@R: c(
     person("Tatsuya", "Shima", , "ts1s1andn@gmail.com", role = c("aut", "cre")),
     person("Etienne", "Bacher", , "etienne.bacher@protonmail.com", role = "aut",
@@ -13,6 +13,9 @@ Description: Lightning-fast 'DataFrame' library written in 'Rust'. Convert
     interoperable with the package 'arrow', as both are based on the
     'Apache Arrow' Columnar Format.
 License: MIT + file LICENSE
+URL: https://pola-rs.github.io/r-polars/,
+    https://github.com/pola-rs/r-polars,
+    https://rpolars.r-universe.dev/polars
 Depends:
     R (>= 4.3)
 Imports:
@@ -39,7 +42,7 @@ Suggests:
     tibble (>= 3.3.0),
     vctrs,
     withr
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Config/Needs/dev: devtools, lifecycle, readr, glue, RcppTOML, smvr
 Config/Needs/lint: fs, lintr

--- a/man/polars-package.Rd
+++ b/man/polars-package.Rd
@@ -8,6 +8,15 @@
 \description{
 Lightning-fast 'DataFrame' library written in 'Rust'. Convert R data to 'Polars' data and vice versa. Perform fast, lazy, larger-than-memory and optimized data queries. 'Polars' is interoperable with the package 'arrow', as both are based on the 'Apache Arrow' Columnar Format.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://pola-rs.github.io/r-polars/}
+  \item \url{https://github.com/pola-rs/r-polars}
+  \item \url{https://rpolars.r-universe.dev/polars}
+}
+
+}
 \author{
 \strong{Maintainer}: Tatsuya Shima \email{ts1s1andn@gmail.com}
 


### PR DESCRIPTION
At the last upgrade, the minor version needed to be set to 9000, but I misread the field and set it to 0.