### PR TITLE
refactor: Use the `lengths()` function to get each length of list elements

### DIFF
--- a/R/as_polars_df.R
+++ b/R/as_polars_df.R
@@ -180,8 +180,7 @@ as_polars_df.list <- function(x, ...) {
   list_of_series <- lapply(x, \(column) eval(call2("as_polars_series", column, !!!.args)))
 
   # Series with length 1 should be recycled
-  unique_lengths <- vapply(list_of_series, length, integer(1)) |>
-    unique()
+  unique_lengths <- unique(lengths(list_of_series))
   n_lengths <- length(unique_lengths)
 
   list_of_plr_series <- if (n_lengths <= 1L) {


### PR DESCRIPTION
`lengths()` is more readable and more performant:

``` r
my_list <- rep(list(1:10), 10000)

bench::mark(
  vapply = vapply(my_list, length, integer(1)) |>
    unique(),
  lengths = unique(lengths(my_list))
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 vapply       1.47ms   1.51ms      640.     206KB     35.2
#> 2 lengths    103.92µs 107.01µs     8190.     206KB     29.4
```