### PR TITLE
fix!: The `join_nulls` arguments are renamed to `nulls_equal` like Python Polars

### DIFF
--- a/R/000-wrappers.R
+++ b/R/000-wrappers.R
@@ -3654,9 +3654,9 @@ class(`PlRExpr`) <- c("PlRExpr__bundle", "savvy_polars__sealed")
 }
 
 `PlRLazyFrame_join` <- function(self) {
-  function(`other`, `left_on`, `right_on`, `allow_parallel`, `force_parallel`, `join_nulls`, `how`, `suffix`, `validate`, `maintain_order`, `coalesce` = NULL) {
+  function(`other`, `left_on`, `right_on`, `allow_parallel`, `force_parallel`, `nulls_equal`, `how`, `suffix`, `validate`, `maintain_order`, `coalesce` = NULL) {
     `other` <- .savvy_extract_ptr(`other`, "PlRLazyFrame")
-    .savvy_wrap_PlRLazyFrame(.Call(savvy_PlRLazyFrame_join__impl, `self`, `other`, `left_on`, `right_on`, `allow_parallel`, `force_parallel`, `join_nulls`, `how`, `suffix`, `validate`, `maintain_order`, `coalesce`))
+    .savvy_wrap_PlRLazyFrame(.Call(savvy_PlRLazyFrame_join__impl, `self`, `other`, `left_on`, `right_on`, `allow_parallel`, `force_parallel`, `nulls_equal`, `how`, `suffix`, `validate`, `maintain_order`, `coalesce`))
   }
 }
 

--- a/R/dataframe-frame.R
+++ b/R/dataframe-frame.R
@@ -883,11 +883,11 @@ dataframe__join <- function(
   right_on = NULL,
   suffix = "_right",
   validate = c("m:m", "1:m", "m:1", "1:1"),
-  join_nulls = FALSE,
+  nulls_equal = FALSE,
+  coalesce = NULL,
   maintain_order = c("none", "left", "right", "left_right", "right_left"),
   allow_parallel = TRUE,
-  force_parallel = FALSE,
-  coalesce = NULL
+  force_parallel = FALSE
 ) {
   wrap({
     check_polars_df(other)
@@ -899,7 +899,7 @@ dataframe__join <- function(
       how = how,
       suffix = suffix,
       validate = validate,
-      join_nulls = join_nulls,
+      nulls_equal = nulls_equal,
       coalesce = coalesce,
       maintain_order = maintain_order
     )$collect(`_eager` = TRUE)

--- a/R/lazyframe-frame.R
+++ b/R/lazyframe-frame.R
@@ -1292,7 +1292,7 @@ lazyframe__unique <- function(
 #'
 #' Note that this is currently not supported by the streaming engine.
 #'
-#' @param join_nulls Join on null values. By default null values will never
+#' @param nulls_equal Join on null values. By default null values will never
 #'   produce matches.
 #' @param allow_parallel Allow the physical plan to optionally evaluate the
 #'   computation of both LazyFrames up to the join in parallel.
@@ -1347,11 +1347,11 @@ lazyframe__join <- function(
   right_on = NULL,
   suffix = "_right",
   validate = c("m:m", "1:m", "m:1", "1:1"),
-  join_nulls = FALSE,
+  nulls_equal = FALSE,
+  coalesce = NULL,
   maintain_order = c("none", "left", "right", "left_right", "right_left"),
   allow_parallel = TRUE,
-  force_parallel = FALSE,
-  coalesce = NULL
+  force_parallel = FALSE
 ) {
   wrap({
     check_dots_empty0(...)
@@ -1391,7 +1391,7 @@ lazyframe__join <- function(
           right_on = list(),
           how = how,
           validate = validate,
-          join_nulls = join_nulls,
+          nulls_equal = nulls_equal,
           suffix = suffix,
           allow_parallel = allow_parallel,
           force_parallel = force_parallel,
@@ -1416,7 +1416,7 @@ lazyframe__join <- function(
       right_on = rexprs_right,
       how = how,
       validate = validate,
-      join_nulls = join_nulls,
+      nulls_equal = nulls_equal,
       suffix = suffix,
       allow_parallel = allow_parallel,
       force_parallel = force_parallel,

--- a/man/dataframe__join.Rd
+++ b/man/dataframe__join.Rd
@@ -13,11 +13,11 @@ dataframe__join(
   right_on = NULL,
   suffix = "_right",
   validate = c("m:m", "1:m", "m:1", "1:1"),
-  join_nulls = FALSE,
+  nulls_equal = FALSE,
+  coalesce = NULL,
   maintain_order = c("none", "left", "right", "left_right", "right_left"),
   allow_parallel = TRUE,
-  force_parallel = FALSE,
-  coalesce = NULL
+  force_parallel = FALSE
 )
 }
 \arguments{
@@ -61,8 +61,17 @@ datasets;
 
 Note that this is currently not supported by the streaming engine.}
 
-\item{join_nulls}{Join on null values. By default null values will never
+\item{nulls_equal}{Join on null values. By default null values will never
 produce matches.}
+
+\item{coalesce}{Coalescing behavior (merging of join columns).
+\itemize{
+\item \code{NULL}: join specific.
+\item \code{TRUE}: Always coalesce join columns.
+\item \code{FALSE}: Never coalesce join columns.
+Note that joining on any other expressions than \code{col} will turn off
+coalescing.
+}}
 
 \item{maintain_order}{Which frame row order to preserve, if any. Do not rely
 on any observed ordering without explicitly setting this parameter, as your
@@ -84,15 +93,6 @@ computation of both DataFrames up to the join in parallel.}
 
 \item{force_parallel}{Force the physical plan to evaluate the computation of
 both DataFrames up to the join in parallel.}
-
-\item{coalesce}{Coalescing behavior (merging of join columns).
-\itemize{
-\item \code{NULL}: join specific.
-\item \code{TRUE}: Always coalesce join columns.
-\item \code{FALSE}: Never coalesce join columns.
-Note that joining on any other expressions than \code{col} will turn off
-coalescing.
-}}
 }
 \value{
 A polars \link{DataFrame}

--- a/man/lazyframe__join.Rd
+++ b/man/lazyframe__join.Rd
@@ -13,11 +13,11 @@ lazyframe__join(
   right_on = NULL,
   suffix = "_right",
   validate = c("m:m", "1:m", "m:1", "1:1"),
-  join_nulls = FALSE,
+  nulls_equal = FALSE,
+  coalesce = NULL,
   maintain_order = c("none", "left", "right", "left_right", "right_left"),
   allow_parallel = TRUE,
-  force_parallel = FALSE,
-  coalesce = NULL
+  force_parallel = FALSE
 )
 }
 \arguments{
@@ -61,8 +61,17 @@ datasets;
 
 Note that this is currently not supported by the streaming engine.}
 
-\item{join_nulls}{Join on null values. By default null values will never
+\item{nulls_equal}{Join on null values. By default null values will never
 produce matches.}
+
+\item{coalesce}{Coalescing behavior (merging of join columns).
+\itemize{
+\item \code{NULL}: join specific.
+\item \code{TRUE}: Always coalesce join columns.
+\item \code{FALSE}: Never coalesce join columns.
+Note that joining on any other expressions than \code{col} will turn off
+coalescing.
+}}
 
 \item{maintain_order}{Which frame row order to preserve, if any. Do not rely
 on any observed ordering without explicitly setting this parameter, as your
@@ -84,15 +93,6 @@ computation of both LazyFrames up to the join in parallel.}
 
 \item{force_parallel}{Force the physical plan to evaluate the computation of
 both LazyFrames up to the join in parallel.}
-
-\item{coalesce}{Coalescing behavior (merging of join columns).
-\itemize{
-\item \code{NULL}: join specific.
-\item \code{TRUE}: Always coalesce join columns.
-\item \code{FALSE}: Never coalesce join columns.
-Note that joining on any other expressions than \code{col} will turn off
-coalescing.
-}}
 }
 \value{
 A polars \link{LazyFrame}

--- a/src/init.c
+++ b/src/init.c
@@ -2509,8 +2509,8 @@ SEXP savvy_PlRLazyFrame_group_by_dynamic__impl(SEXP self__, SEXP c_arg__index_co
     return handle_result(res);
 }
 
-SEXP savvy_PlRLazyFrame_join__impl(SEXP self__, SEXP c_arg__other, SEXP c_arg__left_on, SEXP c_arg__right_on, SEXP c_arg__allow_parallel, SEXP c_arg__force_parallel, SEXP c_arg__join_nulls, SEXP c_arg__how, SEXP c_arg__suffix, SEXP c_arg__validate, SEXP c_arg__maintain_order, SEXP c_arg__coalesce) {
-    SEXP res = savvy_PlRLazyFrame_join__ffi(self__, c_arg__other, c_arg__left_on, c_arg__right_on, c_arg__allow_parallel, c_arg__force_parallel, c_arg__join_nulls, c_arg__how, c_arg__suffix, c_arg__validate, c_arg__maintain_order, c_arg__coalesce);
+SEXP savvy_PlRLazyFrame_join__impl(SEXP self__, SEXP c_arg__other, SEXP c_arg__left_on, SEXP c_arg__right_on, SEXP c_arg__allow_parallel, SEXP c_arg__force_parallel, SEXP c_arg__nulls_equal, SEXP c_arg__how, SEXP c_arg__suffix, SEXP c_arg__validate, SEXP c_arg__maintain_order, SEXP c_arg__coalesce) {
+    SEXP res = savvy_PlRLazyFrame_join__ffi(self__, c_arg__other, c_arg__left_on, c_arg__right_on, c_arg__allow_parallel, c_arg__force_parallel, c_arg__nulls_equal, c_arg__how, c_arg__suffix, c_arg__validate, c_arg__maintain_order, c_arg__coalesce);
     return handle_result(res);
 }
 

--- a/src/rust/api.h
+++ b/src/rust/api.h
@@ -505,7 +505,7 @@ SEXP savvy_PlRLazyFrame_fill_nan__ffi(SEXP self__, SEXP c_arg__fill_value);
 SEXP savvy_PlRLazyFrame_filter__ffi(SEXP self__, SEXP c_arg__predicate);
 SEXP savvy_PlRLazyFrame_group_by__ffi(SEXP self__, SEXP c_arg__by, SEXP c_arg__maintain_order);
 SEXP savvy_PlRLazyFrame_group_by_dynamic__ffi(SEXP self__, SEXP c_arg__index_column, SEXP c_arg__every, SEXP c_arg__period, SEXP c_arg__offset, SEXP c_arg__label, SEXP c_arg__include_boundaries, SEXP c_arg__closed, SEXP c_arg__group_by, SEXP c_arg__start_by);
-SEXP savvy_PlRLazyFrame_join__ffi(SEXP self__, SEXP c_arg__other, SEXP c_arg__left_on, SEXP c_arg__right_on, SEXP c_arg__allow_parallel, SEXP c_arg__force_parallel, SEXP c_arg__join_nulls, SEXP c_arg__how, SEXP c_arg__suffix, SEXP c_arg__validate, SEXP c_arg__maintain_order, SEXP c_arg__coalesce);
+SEXP savvy_PlRLazyFrame_join__ffi(SEXP self__, SEXP c_arg__other, SEXP c_arg__left_on, SEXP c_arg__right_on, SEXP c_arg__allow_parallel, SEXP c_arg__force_parallel, SEXP c_arg__nulls_equal, SEXP c_arg__how, SEXP c_arg__suffix, SEXP c_arg__validate, SEXP c_arg__maintain_order, SEXP c_arg__coalesce);
 SEXP savvy_PlRLazyFrame_join_asof__ffi(SEXP self__, SEXP c_arg__other, SEXP c_arg__left_on, SEXP c_arg__right_on, SEXP c_arg__allow_parallel, SEXP c_arg__force_parallel, SEXP c_arg__suffix, SEXP c_arg__coalesce, SEXP c_arg__strategy, SEXP c_arg__allow_eq, SEXP c_arg__check_sortedness, SEXP c_arg__left_by, SEXP c_arg__right_by, SEXP c_arg__tolerance, SEXP c_arg__tolerance_str);
 SEXP savvy_PlRLazyFrame_join_where__ffi(SEXP self__, SEXP c_arg__other, SEXP c_arg__predicates, SEXP c_arg__suffix);
 SEXP savvy_PlRLazyFrame_max__ffi(SEXP self__);

--- a/src/rust/src/lazyframe/general.rs
+++ b/src/rust/src/lazyframe/general.rs
@@ -467,7 +467,7 @@ impl PlRLazyFrame {
         right_on: ListSexp,
         allow_parallel: bool,
         force_parallel: bool,
-        join_nulls: bool,
+        nulls_equal: bool,
         how: &str,
         suffix: &str,
         validate: &str,
@@ -494,7 +494,7 @@ impl PlRLazyFrame {
             .right_on(right_on)
             .allow_parallel(allow_parallel)
             .force_parallel(force_parallel)
-            .join_nulls(join_nulls)
+            .join_nulls(nulls_equal)
             .how(how)
             .coalesce(coalesce)
             .validate(validate)

--- a/tests/testthat/test-lazyframe-frame.R
+++ b/tests/testthat/test-lazyframe-frame.R
@@ -607,7 +607,7 @@ test_that("argument 'validate' works", {
   )
 })
 
-test_that("argument 'join_nulls' works", {
+test_that("argument 'nulls_equal' works", {
   df1 <- pl$DataFrame(x = c(NA, letters[1:2]), y = 1:3)
   df2 <- pl$DataFrame(x = c(NA, letters[2:3]), y2 = 4:6)
 
@@ -621,7 +621,7 @@ test_that("argument 'join_nulls' works", {
 
   # consider nulls as a valid key
   expect_query_equal(
-    .input$join(.input2, on = "x", join_nulls = TRUE),
+    .input$join(.input2, on = "x", nulls_equal = TRUE),
     .input = df1,
     .input2 = df2,
     pl$DataFrame(x = c(NA, "b"), y = c(1L, 3L), y2 = c(4L, 5L))
@@ -630,7 +630,7 @@ test_that("argument 'join_nulls' works", {
   # several nulls
   df3 <- pl$DataFrame(x = c(NA, letters[2:3], NA), y2 = 4:7)
   expect_query_equal(
-    .input$join(.input2, on = "x", join_nulls = TRUE),
+    .input$join(.input2, on = "x", nulls_equal = TRUE),
     .input = df1,
     .input2 = df3,
     pl$DataFrame(x = c(NA, "b", NA), y = c(1L, 3L, 1L), y2 = c(4L, 5L, 7L))


### PR DESCRIPTION
Fix pola-rs/r-polars#1422