### PR TITLE
fix: Expose the `schema` argument of `compute_tree_format` to the R side and mark `as_dot` as experimental

### DIFF
--- a/R/000-wrappers.R
+++ b/R/000-wrappers.R
@@ -1243,8 +1243,8 @@ class(`PlRDataType`) <- c("PlRDataType__bundle", "savvy_polars__sealed")
 }
 
 `PlRExpr_compute_tree_format` <- function(self) {
-  function(`display_as_dot`, `schema` = NULL) {
-    .Call(savvy_PlRExpr_compute_tree_format__impl, `self`, `display_as_dot`, `schema`)
+  function(`as_dot`, `schema` = NULL) {
+    .Call(savvy_PlRExpr_compute_tree_format__impl, `self`, `as_dot`, `schema`)
   }
 }
 

--- a/R/expr-meta.R
+++ b/R/expr-meta.R
@@ -193,9 +193,11 @@ expr_meta_root_names <- function() {
 #' Format the expression as a tree
 #'
 #' @inheritParams rlang::args_dots_empty
-#' @param as_dot If `TRUE`, show the dot syntax that can be used in other
-#' packages, such as `DiagrammeR`.
-#'
+#' @param as_dot `r lifecycle::badge("experimental")`
+#'   If `TRUE`, show the dot syntax that can be used in other
+#'   packages, such as `DiagrammeR`.
+#' @param schema An optional schema. Must be `NULL` or a named list of
+#'   [DataType].
 #' @return
 #' A string, either with the tree itself (if `as_dot = FALSE`) or with the
 #' corresponding GraphViz code (if `as_dot = TRUE`).
@@ -209,10 +211,15 @@ expr_meta_root_names <- function() {
 #' graph <- my_expr$meta$tree_format(as_dot = TRUE)
 #' DiagrammeR::grViz(graph)
 #' }
-expr_meta_tree_format <- function(..., as_dot = FALSE) {
+expr_meta_tree_format <- function(..., as_dot = FALSE, schema = NULL) {
   wrap({
     check_dots_empty0(...)
-    self$`_rexpr`$compute_tree_format(display_as_dot = as_dot)
+    check_list_of_polars_dtype(schema, allow_null = TRUE)
+
+    if (!is.null(schema)) {
+      schema <- parse_into_list_of_datatypes(!!!schema)
+    }
+    self$`_rexpr`$compute_tree_format(as_dot = as_dot, schema = schema)
   })
 }
 

--- a/man/expr_meta_tree_format.Rd
+++ b/man/expr_meta_tree_format.Rd
@@ -4,13 +4,17 @@
 \alias{expr_meta_tree_format}
 \title{Format the expression as a tree}
 \usage{
-expr_meta_tree_format(..., as_dot = FALSE)
+expr_meta_tree_format(..., as_dot = FALSE, schema = NULL)
 }
 \arguments{
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{as_dot}{If \code{TRUE}, show the dot syntax that can be used in other
+\item{as_dot}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+If \code{TRUE}, show the dot syntax that can be used in other
 packages, such as \code{DiagrammeR}.}
+
+\item{schema}{An optional schema. Must be \code{NULL} or a named list of
+\link{DataType}.}
 }
 \value{
 A string, either with the tree itself (if \code{as_dot = FALSE}) or with the

--- a/src/init.c
+++ b/src/init.c
@@ -914,8 +914,8 @@ SEXP savvy_PlRExpr_clip__impl(SEXP self__, SEXP c_arg__min, SEXP c_arg__max) {
     return handle_result(res);
 }
 
-SEXP savvy_PlRExpr_compute_tree_format__impl(SEXP self__, SEXP c_arg__display_as_dot, SEXP c_arg__schema) {
-    SEXP res = savvy_PlRExpr_compute_tree_format__ffi(self__, c_arg__display_as_dot, c_arg__schema);
+SEXP savvy_PlRExpr_compute_tree_format__impl(SEXP self__, SEXP c_arg__as_dot, SEXP c_arg__schema) {
+    SEXP res = savvy_PlRExpr_compute_tree_format__ffi(self__, c_arg__as_dot, c_arg__schema);
     return handle_result(res);
 }
 

--- a/src/rust/api.h
+++ b/src/rust/api.h
@@ -184,7 +184,7 @@ SEXP savvy_PlRExpr_cat_get_categories__ffi(SEXP self__);
 SEXP savvy_PlRExpr_cbrt__ffi(SEXP self__);
 SEXP savvy_PlRExpr_ceil__ffi(SEXP self__);
 SEXP savvy_PlRExpr_clip__ffi(SEXP self__, SEXP c_arg__min, SEXP c_arg__max);
-SEXP savvy_PlRExpr_compute_tree_format__ffi(SEXP self__, SEXP c_arg__display_as_dot, SEXP c_arg__schema);
+SEXP savvy_PlRExpr_compute_tree_format__ffi(SEXP self__, SEXP c_arg__as_dot, SEXP c_arg__schema);
 SEXP savvy_PlRExpr_cos__ffi(SEXP self__);
 SEXP savvy_PlRExpr_cosh__ffi(SEXP self__);
 SEXP savvy_PlRExpr_cot__ffi(SEXP self__);

--- a/src/rust/src/expr/meta.rs
+++ b/src/rust/src/expr/meta.rs
@@ -114,7 +114,7 @@ impl PlRExpr {
         Ok(self.inner.clone().meta()._into_selector().into())
     }
 
-    fn compute_tree_format(&self, display_as_dot: bool, schema: Option<ListSexp>) -> Result<Sexp> {
+    fn compute_tree_format(&self, as_dot: bool, schema: Option<ListSexp>) -> Result<Sexp> {
         let schema = match schema {
             Some(s) => Some(<Wrap<Schema>>::try_from(s)?.0),
             None => None,
@@ -123,7 +123,7 @@ impl PlRExpr {
             .inner
             .clone()
             .meta()
-            .into_tree_formatter(display_as_dot, schema.as_ref())
+            .into_tree_formatter(as_dot, schema.as_ref())
             .map_err(RPolarsErr::from)?;
         format!("{e}").try_into()
     }


### PR DESCRIPTION
Fix pola-rs/r-polars#1416